### PR TITLE
compatibility with tibble

### DIFF
--- a/R/dndscv.R
+++ b/R/dndscv.R
@@ -44,7 +44,7 @@ dndscv = function(mutations, gene_list = NULL, refdb = "hg19", sm = "192r_3w", k
 
     mutations = mutations[,1:5] # Restricting input matrix to first 5 columns
     mutations[,c(1,2,4,5)] = lapply(mutations[,c(1,2,4,5)], as.character) # Factors to character
-    mutations[,3] = as.numeric(mutations[,3]) # Chromosome position as numeric
+    mutations[[3]] = as.numeric(mutations[[3]]) # Chromosome position as numeric
     mutations = mutations[mutations[,4]!=mutations[,5],] # Removing mutations with identical reference and mutant base
     colnames(mutations) = c("sampleID","chr","pos","ref","mut")
     


### PR DESCRIPTION
May I suggest a little tweak in `dndscv()` that would make it compatible with tibble package. Tidyverse packages are popular and many people use data.frame and tibble interchangeably. Since `as.numeric(tibble)` throws an error, providing tibble to `dndscv()` results in error since the introduction of line 47. My tweak would be harmless and allows `dndscv(tibble)`.